### PR TITLE
【add】sidebarMenu-footer-01 アイコン、ボタンなどの位置調節

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "jotai": "^1.8.5",
     "next": "12.3.1",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "react-icons": "^4.6.0"
   },
   "devDependencies": {
     "@babel/core": "^7.19.3",

--- a/src/features/Menu/MenuFooter.tsx
+++ b/src/features/Menu/MenuFooter.tsx
@@ -3,28 +3,38 @@ import {
   Avatar,
   Text,
   Center,
-  Box,
+  Icon,
   Stack,
   Button,
 } from '@chakra-ui/react'
-import { EmailIcon, ArrowForwardIcon } from '@chakra-ui/icons'
+import { FiLogOut, FiUser, FiChevronRight } from 'react-icons/fi'
 
 const MenuFooter = () => {
   return (
-    <Flex bg='blue' h={150} flexFlow='column'>
-      <Flex flexFlow='row'>
-        <Stack direction='row'>
-          <Avatar src='' name='a a' />
-        </Stack>
-        <Text fontSize='xs'>Chris D Kasahara</Text>
+    <Flex bg='blue' h={200} flexFlow='column' p={4}>
+      <Flex
+        flexFlow='row'
+        border='2px'
+        borderRadius='10px'
+        borderColor='white'
+        p={4}
+        mb={1}
+      >
         <Center>
-          <Box m={15}>{'>'}</Box>
+          <Avatar src='' name='Chris Kasahara' size='md' mr={2} />
+          <Text fontSize='lg' fontWeight='bold' color='white'>
+            Chris D Kasahara
+          </Text>
+          <Icon p={1} w={5} color='white' as={FiChevronRight} />
         </Center>
       </Flex>
       <Flex>
-        <Stack direction='row' spacing={4}>
-          <Button rightIcon={<ArrowForwardIcon />} colorScheme='teal'>
-            Sign Out
+        <Stack direction='row' spacing={3} p={1}>
+          <Button size='sm' p={6} rightIcon={<FiLogOut />}>
+            SIGN OUT
+          </Button>
+          <Button size='sm' p={6} rightIcon={<FiUser />}>
+            SWITCH ACC
           </Button>
         </Stack>
       </Flex>

--- a/src/features/Menu/Sidebar.tsx
+++ b/src/features/Menu/Sidebar.tsx
@@ -7,7 +7,7 @@ import NavItem from './NavItem'
 const Sidebar = () => {
   console.log(menuContents)
   return (
-    <Flex flexFlow='column' w='240px' bg='red' h='100vh'>
+    <Flex flexFlow='column' w='300px' bg='red' h='100vh'>
       <MenuHeader />
       <Flex flexGrow={1} flexFlow='column'>
         <List spacing={0} p={0} mt={0}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9881,6 +9881,11 @@ react-focus-lock@^2.9.1:
     use-callback-ref "^1.3.0"
     use-sidecar "^1.1.2"
 
+react-icons@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.6.0.tgz#f83eda179af5d02c047449a20b702c858653d397"
+  integrity sha512-rR/L9m9340yO8yv1QT1QurxWQvWpbNHqVX0fzMln2HEb9TEIrQRGsqiNFQfiv9/JEUbyHmHPlNTB2LWm2Ttz0g==
+
 react-inspector@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-5.1.1.tgz#58476c78fde05d5055646ed8ec02030af42953c8"


### PR DESCRIPTION
# 機能追加:sparkles:

## 概要:page_facing_up:
- アイコン、ボタンなどの位置調節

## モチベーション:fire:
- フッターのブラッシュアップ

## 実装:wrench:
- アイコンの位置を中央へ
- ログイン系ボタンを下部に配置

## 懸念点:pushpin:
- 特になし

## 備考:pencil2:
- 特になし