### PR TITLE
add/sidebarMenu-03 サブメニュー追加・開閉機能追加

### DIFF
--- a/src/atom/MenuAtom.ts
+++ b/src/atom/MenuAtom.ts
@@ -2,3 +2,12 @@ import { atom } from 'jotai'
 import { menuContents } from '../common/consts'
 
 export const menuContentsAtom = atom(menuContents)
+export const menuOpeningStateAtom = atom({
+  mainMenuState: {
+    isOpen: true,
+  },
+  subMenuState: {
+    isAnyOpen: false,
+    OpenSubMenuId: '',
+  },
+})

--- a/src/common/consts.ts
+++ b/src/common/consts.ts
@@ -21,7 +21,56 @@ export const menuContents: menuContentsType = [
     path: '/',
     icon: FiBook,
     name: 'PICTURE BOOK',
-    childMenuContents: [],
+    childMenuContents: [
+      {
+        id: 'nekemf',
+        path: '/',
+        icon: 'none',
+        name: 'T-REX',
+      },
+      {
+        id: 'rfrgsg',
+        path: '/',
+        icon: 'none',
+        name: 'Pteranodon',
+      },
+      {
+        id: 'qqarfw',
+        path: '/',
+        icon: 'none',
+        name: 'Stegosaurus',
+      },
+      {
+        id: 'tdchdx',
+        path: '/',
+        icon: 'none',
+        name: 'Triceratops',
+      },
+      {
+        id: 'jrcsxs',
+        path: '/',
+        icon: 'none',
+        name: 'ParasauroLophus',
+      },
+      {
+        id: 'eedddw',
+        path: '/',
+        icon: 'none',
+        name: 'Spinosaurus',
+      },
+      {
+        id: 'ggegss',
+        path: '/',
+        icon: 'none',
+        name: 'Brachiosaurus',
+      },
+      {
+        id: 'eggfsg',
+        path: '/',
+        icon: 'none',
+        name: 'Plesiosaurus',
+      },
+    ],
   },
   {
     id: 'sebsfb',

--- a/src/features/Menu/ChildMenu.tsx
+++ b/src/features/Menu/ChildMenu.tsx
@@ -1,1 +1,24 @@
+import { Flex, ListItem, Center, Icon } from '@chakra-ui/react'
+import { useAtom } from 'jotai'
+import { menuContentsAtom } from '../../atom/MenuAtom'
+import { childMenuContentsPropsType } from '../../types/Manu.type'
+import { FiChevronDown } from 'react-icons/fi'
 
+const ChildMenu = ({ id, parentId }: childMenuContentsPropsType) => {
+  const [menuContents] = useAtom(menuContentsAtom)
+  const navItemContens = menuContents.find(
+    (menuContentsItem) => menuContentsItem.id === parentId
+  )
+  const childMenuItem = navItemContens?.childMenuContents?.find(
+    (chlidContentsItem) => chlidContentsItem.id === id
+  )
+  return (
+    <Flex color='gray.600' cursor='pointer' _hover={{ bg: 'gray.700' }} pl={10}>
+      <ListItem my={15} h={30} flexGrow={1} fontSize='lg' fontWeight='bold'>
+        {childMenuItem?.name}
+      </ListItem>
+    </Flex>
+  )
+}
+
+export default ChildMenu

--- a/src/features/Menu/MenuFooter.tsx
+++ b/src/features/Menu/MenuFooter.tsx
@@ -1,3 +1,4 @@
+import { useAtom } from 'jotai'
 import {
   Flex,
   Avatar,
@@ -8,28 +9,34 @@ import {
   Button,
 } from '@chakra-ui/react'
 import { FiLogOut, FiUser, FiChevronRight } from 'react-icons/fi'
+import { menuOpeningStateAtom } from '../../atom/MenuAtom'
 
 const MenuFooter = () => {
+  const [menuOpeningState, setMenuOpeningState] = useAtom(menuOpeningStateAtom)
+  const { mainMenuState } = menuOpeningState
+  const { isOpen } = mainMenuState
   return (
-    <Flex bg='blue' h={200} flexFlow='column' p={4}>
+    <Flex h={250} w='100%' flexFlow='column' p={5}>
       <Flex
         flexFlow='row'
         border='2px'
         borderRadius='10px'
-        borderColor='white'
-        p={4}
+        borderColor='gray.200'
+        py={4}
+        pl={7}
         mb={1}
+        cursor='pointer'
+        _hover={{ bg: 'gray.200' }}
       >
-        <Center>
+        <Center flexFlow='column' flexGrow={1}>
           <Avatar src='' name='Chris Kasahara' size='md' mr={2} />
           <Text fontSize='lg' fontWeight='bold' color='white'>
             Chris D Kasahara
           </Text>
-          <Icon p={1} w={5} color='white' as={FiChevronRight} />
         </Center>
       </Flex>
       <Flex>
-        <Stack direction='row' spacing={3} p={1}>
+        <Stack direction='row' spacing={2} py={1}>
           <Button size='sm' p={6} rightIcon={<FiLogOut />}>
             SIGN OUT
           </Button>
@@ -39,6 +46,41 @@ const MenuFooter = () => {
         </Stack>
       </Flex>
     </Flex>
+  )
+}
+
+const FooterContentsWhenMenuOpen = () => {
+  return (
+    <>
+      <Flex
+        flexFlow='row'
+        border='2px'
+        borderRadius='10px'
+        borderColor='gray.200'
+        py={4}
+        pl={7}
+        mb={1}
+        cursor='pointer'
+        _hover={{ bg: 'gray.200' }}
+      >
+        <Center flexFlow='column' flexGrow={1}>
+          <Avatar src='' name='Chris Kasahara' size='md' mr={2} />
+          <Text fontSize='lg' fontWeight='bold' color='white'>
+            Chris D Kasahara
+          </Text>
+        </Center>
+      </Flex>
+      <Flex>
+        <Stack direction='row' spacing={2} py={1}>
+          <Button size='sm' p={6} rightIcon={<FiLogOut />}>
+            SIGN OUT
+          </Button>
+          <Button size='sm' p={6} rightIcon={<FiUser />}>
+            SWITCH ACC
+          </Button>
+        </Stack>
+      </Flex>
+    </>
   )
 }
 

--- a/src/features/Menu/MenuHeader.tsx
+++ b/src/features/Menu/MenuHeader.tsx
@@ -1,10 +1,26 @@
-import { Text, Center, Flex, Icon } from '@chakra-ui/react'
+import { useAtom } from 'jotai'
+import { Text, Center, Flex, Icon, Button } from '@chakra-ui/react'
 import { FiSidebar } from 'react-icons/fi'
+import { menuOpeningStateAtom } from '../../atom/MenuAtom'
 
 const MenuHeader = () => {
+  const [menuOpeningState, setMenuOpeningState] = useAtom(menuOpeningStateAtom)
+  const { mainMenuState } = menuOpeningState
+  const { isOpen } = mainMenuState
+
+  const onClick = () => {
+    setMenuOpeningState((value) => {
+      mainMenuState.isOpen = !mainMenuState.isOpen
+      return {
+        ...value,
+        mainMenuState,
+      }
+    })
+  }
+
   return (
-    <Flex h='60px' pos='relative'>
-      <Flex flexGrow={1}>
+    <Flex h='60px' pos='relative' flexShrink={0}>
+      <Flex>
         <Text
           ml={5}
           my={2}
@@ -12,23 +28,26 @@ const MenuHeader = () => {
           fontSize='2xl'
           fontWeight='bold'
           color='gray.200'
+          display={isOpen ? 'block' : 'none'}
         >
           Dinosaur
         </Text>
       </Flex>
-      <Flex
+      <Button
         w='50px'
         h='50px'
         pos='absolute'
         bg='gray.100'
-        borderLeftRadius={35}
-        right={0}
-        textAlign='center'
+        borderLeftRadius={isOpen ? 35 : 0}
+        borderRightRadius={isOpen ? 0 : 35}
+        right={isOpen ? 0 : '-50px'}
+        onClick={onClick}
+        cursor='pointer'
       >
         <Center>
           <Icon w='50px' h='25px' strokeWidth='2px' as={FiSidebar} />
         </Center>
-      </Flex>
+      </Button>
     </Flex>
   )
 }

--- a/src/features/Menu/NavItem.tsx
+++ b/src/features/Menu/NavItem.tsx
@@ -1,37 +1,87 @@
-import { ListIcon, Flex, ListItem, Center, Icon } from '@chakra-ui/react'
+import { ListIcon, Flex, ListItem, Center, Icon, List } from '@chakra-ui/react'
 import { useAtom } from 'jotai'
-import { menuContentsAtom } from '../../atom/MenuAtom'
+import { menuContentsAtom, menuOpeningStateAtom } from '../../atom/MenuAtom'
 import { navItemType } from '../../types/Manu.type'
 import { FiChevronDown } from 'react-icons/fi'
+import ChildMenu from './ChildMenu'
 
 const NavItem = ({ id }: navItemType) => {
   const [menuContents] = useAtom(menuContentsAtom)
+  const [menuOpeningState, setMenuOpeningState] = useAtom(menuOpeningStateAtom)
+  const { mainMenuState } = menuOpeningState
+  const { subMenuState } = menuOpeningState
+  const isMainMenuOpen = mainMenuState.isOpen
+  const isSubMenuOpen = subMenuState.isAnyOpen
+
+  const onClick = () => {
+    navItemContens.childMenuContents &&
+      navItemContens.childMenuContents?.length > 0 &&
+      setMenuOpeningState((value) => {
+        subMenuState.isAnyOpen = !subMenuState.isAnyOpen
+        return {
+          ...value,
+          subMenuState: subMenuState,
+        }
+      })
+  }
+
   const navItemContens = menuContents.filter(
     (menuContentsItem) => menuContentsItem.id === id
   )[0]
   return (
-    <Flex _hover={{ bg: 'gray' }}>
-      <ListItem
-        my={15}
-        h={30}
-        flexGrow={1}
-        flexFlow='column'
-        fontSize='lg'
-        fontWeight='bold'
+    <Flex flexFlow='column'>
+      <Flex
         color='gray.200'
+        cursor='pointer'
+        flexFlow='row'
+        _hover={{ bg: 'gray.200', color: 'gray.700' }}
       >
-        <ListIcon
-          mx={15}
-          h={5}
-          w={5}
-          strokeWidth={2}
-          as={navItemContens.icon}
-        />
-        {navItemContens?.name}
-      </ListItem>
-      <Center w='70px'>
-        <Icon as={FiChevronDown} h={5} w={5} strokeWidth='3px' />
-      </Center>
+        <ListItem
+          my={15}
+          h={30}
+          flexGrow={1}
+          flexFlow='row'
+          fontSize='lg'
+          fontWeight='bold'
+        >
+          <ListIcon
+            mx={15}
+            h={5}
+            w={5}
+            strokeWidth={2}
+            as={navItemContens.icon}
+          />
+          {isMainMenuOpen && navItemContens?.name}
+        </ListItem>
+        {navItemContens.childMenuContents &&
+          navItemContens.childMenuContents?.length > 0 &&
+          isSubMenuOpen && (
+            <Center w='70px' onClick={onClick}>
+              <Icon as={FiChevronDown} h={5} w={5} strokeWidth='3px' />
+            </Center>
+          )}
+      </Flex>
+      {isMainMenuOpen && isSubMenuOpen && (
+        <Flex
+          flexGrow={1}
+          flexFlow='column'
+          bg='white'
+          bgGradient='linear(200deg, rgba(160, 160, 160, .5), rgba(250,250,250, .7) 40.71%),
+      linear-gradient(130deg, rgba(200, 200, 200, .4), rgba(250, 250, 250, .5) 80.71%),
+      linear-gradient(320deg, rgba(250, 250, 250, .5), rgba(150, 150, 150, .5) 60.71%),'
+        >
+          <List>
+            {navItemContens.childMenuContents &&
+              navItemContens.childMenuContents.map((childMenuContentsItem) => (
+                <ChildMenu
+                  id={childMenuContentsItem.id}
+                  key={childMenuContentsItem.id}
+                  parentId={navItemContens.id}
+                />
+              ))}
+          </List>
+        </Flex>
+      )}
     </Flex>
   )
 }

--- a/src/features/Menu/Sidebar.tsx
+++ b/src/features/Menu/Sidebar.tsx
@@ -1,19 +1,31 @@
 import { Flex, List } from '@chakra-ui/react'
+import { useAtom } from 'jotai'
 import MenuFooter from './MenuFooter'
 import MenuHeader from './MenuHeader'
 import { menuContents } from '../../common/consts'
 import NavItem from './NavItem'
+import { menuOpeningStateAtom } from '../../atom/MenuAtom'
 
 const Sidebar = () => {
-  console.log(menuContents)
+  const [menuOpeningState] = useAtom(menuOpeningStateAtom)
+  const { isOpen } = menuOpeningState.mainMenuState
+
   return (
     <Flex
       flexFlow='column'
-      w='300px'
+      w={isOpen ? '400px' : '50px'}
       bgGradient='linear(200deg, rgba(95, 2, 67), rgba(17,11,79,.3) 70.71%),
       linear-gradient(135deg, rgba(0,0,120,.8), rgba(0,255,0,0) 60.71%),
       linear-gradient(330deg, rgba(4,0,33), rgba(0,0,0) 80.71%)'
       h='100vh'
+      overflowY={isOpen ? 'scroll' : 'visible'}
+      pos='relative'
+      sx={{
+        '&::-webkit-scrollbar': {
+          display: 'none',
+        },
+        '-ms-overflow-style': 'none',
+      }}
     >
       <MenuHeader />
       <Flex flexGrow={1} flexFlow='column'>

--- a/src/types/Manu.type.ts
+++ b/src/types/Manu.type.ts
@@ -9,7 +9,13 @@ export type navItemType = {
 
 export type childMenuContentsType = {
   id: string
-  path: string
-  name: string
+  path?: string
+  name?: string
+  icon?: IconType | 'none'
 }
+
+export type childMenuContentsPropsType = childMenuContentsType & {
+  parentId: string
+}
+
 export type menuContentsType = navItemType[]


### PR DESCRIPTION
# 機能追加:sparkles:

## 概要:page_facing_up:
- Childメニューの追加・フッターの修正（未完成）・メニュー開閉機能追加・スタイル調整

## モチベーション:fire:
- 本番用に近づける

## 実装:wrench:
- childメニューを新たに追加
- フッターの表示を修正
- メニュー開閉機能の実装
  - ヘッダーのボタンクリックで開閉
  - サブメニューがある項目のみ、アイコンクリックで開閉
  - これに伴い、サイドメニューをスクロール可能に変更


## 懸念点:pushpin:
- 特になし

## 備考:pencil2:
- 特になし